### PR TITLE
Faster (much faster) version of set_tensor_symmetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
+[![Binstar Badge](https://binstar.org/jochym/elastic/badges/version.svg)](https://binstar.org/jochym/phonopy)
+[![Binstar Badge](https://binstar.org/jochym/elastic/badges/downloads.svg)](https://binstar.org/jochym/phonopy)
+
 phonopy
 =======
 
 Phonon code
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-[![Binstar Badge](https://binstar.org/jochym/elastic/badges/version.svg)](https://binstar.org/jochym/phonopy)
-[![Binstar Badge](https://binstar.org/jochym/elastic/badges/downloads.svg)](https://binstar.org/jochym/phonopy)
+[![Binstar Badge](https://binstar.org/jochym/phonopy/badges/version.svg)](https://binstar.org/jochym/phonopy)
+[![Binstar Badge](https://binstar.org/jochym/phonopy/badges/downloads.svg)](https://binstar.org/jochym/phonopy)
+[![Binstar Badge](https://binstar.org/jochym/phonopy/badges/installer/conda.svg)](https://conda.binstar.org/jochym/phonopy)
 
 phonopy
 =======


### PR DESCRIPTION
This is a much faster version of the set_tensor_symmetry_function from the harmonic/force_constants.py. It avoids explicit for loops and uses some numpy tricks for performance. The difference is substantial. For a large system (96at) it is few seconds vs. few minutes (or more). I have tested it against the old function - the results are identical. For large systems the old function was simply unusable.