### PR TITLE
End VASP output files with newline and close file

### DIFF
--- a/phonopy/interface/vasp.py
+++ b/phonopy/interface/vasp.py
@@ -229,6 +229,7 @@ def write_vasp(filename, atoms, direct=True):
     lines = _get_vasp_structure(atoms, direct=direct)
     f = open(filename, 'w')
     f.write(lines)
+    f.close()
 
 def write_supercells_with_displacements(supercell,
                                         cells_with_displacements):
@@ -296,6 +297,7 @@ def _get_vasp_structure(atoms, direct=True):
     lines += "\n"
     lines += "Direct\n"
     lines += get_scaled_positions_lines(scaled_positions)
+    lines += "\n"
 
     return lines
     


### PR DESCRIPTION
Ran into an issue with a user here at NERSC using phonopy and our default VASP executable which is compiled with cray compilers. VASP compiled this way refuses to read POSCAR files unless every line ends with "\n."