### PR TITLE
minor bug fix in the printing of irreducible rep label

### DIFF
--- a/phonopy/phonon/irreps.py
+++ b/phonopy/phonon/irreps.py
@@ -1084,7 +1084,10 @@ class IrReps:
             if self._ir_labels is None:
                 print(text)
             else:
-                print(text + self._ir_labels[i])
+                if self._ir_labels[i] is None:
+                    print(text)
+                else:
+                    print(text + self._ir_labels[i])
             _print_characters(self._characters[i])
             print('')
 


### PR DESCRIPTION

* string concatenation fails if the label is None
