### PR TITLE
phonophy/interface/FHI-aims.py: Bugfix (read of forces)

### DIFF
--- a/phonopy/interface/FHIaims.py
+++ b/phonopy/interface/FHIaims.py
@@ -161,7 +161,7 @@ def read_aims_output(filename):
             forces = []
             for i in range(N):
                 l += 1
-                force = map(float, lines[l].split()[2:5])
+                force = map(float, lines[l].split()[-3:])
                 forces.append(force)
         l += 1
     


### PR DESCRIPTION
FHI-aims output of forces for atoms is
| 999	force1	force2	force3
for less than 1000 atoms and
|1000	force1	force2	force3
for more than 999 atoms. Therefore column have to be counted in reversed order.