### PR TITLE
Optimize `get_equivalent_smallest_vectors` (also, bugfix for HDF5 in python3)

### DIFF
--- a/phonopy/file_IO.py
+++ b/phonopy/file_IO.py
@@ -191,9 +191,7 @@ def parse_FORCE_CONSTANTS(filename="FORCE_CONSTANTS"):
 def read_force_constants_hdf5(filename="force_constants.hdf5"):
     import h5py
     with h5py.File(filename, 'r') as f:
-        fc = f[f.keys()[0]][:]
-        return fc
-    return None
+        return f[next(iter(f.keys()))][:]
 
 #
 # disp.yaml

--- a/phonopy/harmonic/dynamical_matrix.py
+++ b/phonopy/harmonic/dynamical_matrix.py
@@ -366,8 +366,7 @@ def get_equivalent_smallest_vectors(atom_number_supercell,
     positions = np.dot(supercell.get_positions(), np.linalg.inv(reduced_bases))
 
     # Atomic positions are confined into the lattice made of reduced bases.
-    for pos in positions:
-        pos -= np.rint(pos)
+    positions -= np.rint(positions)
 
     p_pos = positions[atom_number_primitive]
     s_pos = positions[atom_number_supercell]

--- a/phonopy/harmonic/dynamical_matrix.py
+++ b/phonopy/harmonic/dynamical_matrix.py
@@ -360,8 +360,6 @@ def get_equivalent_smallest_vectors(atom_number_supercell,
                                     supercell,
                                     primitive_lattice,
                                     symprec):
-    distances = []
-    differences = []
     reduced_bases = get_reduced_bases(supercell.get_cell(), symprec)
     positions = np.dot(supercell.get_positions(), np.linalg.inv(reduced_bases))
 
@@ -370,17 +368,19 @@ def get_equivalent_smallest_vectors(atom_number_supercell,
 
     p_pos = positions[atom_number_primitive]
     s_pos = positions[atom_number_supercell]
-    for i in (-1, 0, 1):
-        for j in (-1, 0, 1):
-            for k in (-1, 0, 1):
-                # The vector arrow is from the atom in primitive to
-                # the atom in supercell cell plus a supercell lattice
-                # point. This is related to determine the phase
-                # convension when building dynamical matrix.
-                diff = s_pos + [i, j, k] - p_pos
-                differences.append(diff)
-                vec = np.dot(diff, reduced_bases)
-                distances.append(np.linalg.norm(vec))
+    
+    # The vector arrow is from the atom in primitive to
+    # the atom in supercell cell plus a supercell lattice
+    # point. This is related to determine the phase
+    # convension when building dynamical matrix.
+    supercell_vectors = np.array([
+        [i, j, k] for i in (-1, 0, 1)
+                  for j in (-1, 0, 1)
+                  for k in (-1, 0, 1)
+    ])
+    
+    differences = s_pos + supercell_vectors - p_pos
+    distances = np.linalg.norm(np.dot(differences, reduced_bases), axis=1)
 
     minimum = min(distances)
     smallest_vectors = []


### PR DESCRIPTION
This optimizes `get_equivalent_smallest_vectors` as [noted here](https://github.com/atztogo/phonopy/issues/40).

It also contains a fix for the `--hdf5` flag in python3, which currently throws an exception.

---

### Info on benchmarks

I tried out various strategies for optimizing this function. The following table collects benchmarks for modifications to the function.  Most were not worth it; see [this table for details](https://github.com/ExpHP/phonopy-eigenvector-tblg-benchmark/edit/master/info/benchmarks.md).

_**This PR only contains the two optimizations found to have the biggest bang for the buck.**_

---

### Further possible optimizations

The big remaining bits I see that can be eliminated now are the delaunay reduction and matrix inverses. **These should probably be precomputed and placed as members on some class, or passed in as an argument.** Unfortunately I don't know the code well enough to know where they best belong.

I experiment with this in the final row in the table (I bench a modification where `get_equivalent_smallest_vectors` takes `reduced_bases` as an argument, which produces another decent 50% speedup).
