### PR TITLE
add compute_permutation C function

### DIFF
--- a/phonopy/harmonic/force_constants.py
+++ b/phonopy/harmonic/force_constants.py
@@ -226,16 +226,12 @@ def get_positions_sent_by_rot_inv(lattice, # column vectors
                                   symprec):
     rot_map_syms = []
     for sym in site_symmetry:
-        rot_map = np.zeros(len(positions), dtype='intc')
-        rot_pos = np.dot(positions, sym.T)
-        is_found = False
-        for i, rot_pos_i in enumerate(rot_pos):
-            diff = positions - rot_pos_i
-            diff -= np.rint(diff)
-            diff = np.dot(diff, lattice.T)
-            j = np.nonzero(np.sqrt(np.sum(diff ** 2, axis=1)) < symprec)[0]
-            rot_map[j] = i
-
+        # inverse permutation of sym;
+        # satisfies 'rotated_positions[rot_map] == positions'
+        rot_map = _compute_permutation_for_rotation(np.dot(positions, sym.T),
+                                                    positions,
+                                                    lattice,
+                                                    symprec)
         rot_map_syms.append(rot_map)
 
     return np.array(rot_map_syms, dtype='intc', order='C')
@@ -810,3 +806,92 @@ def _get_atom_mapping_by_symmetry(atom_list_done,
     print("Input forces are not enough to calculate force constants,")
     print("or something wrong (e.g. crystal structure does not match).")
     raise ValueError
+
+# Get the overall permutation such that
+#
+#        positions_a[perm[i]] == positions_b[i]   (modulo the lattice)
+#
+# or in numpy speak,
+#
+#        positions_a[perm] == positions_b   (modulo the lattice)
+#
+# This version is optimized for the case where positions_a and positions_b
+# are related by a rotation.
+def _compute_permutation_for_rotation(positions_a, # scaled positions
+                                      positions_b,
+                                      lattice, # column vectors
+                                      symprec):
+
+    # Sort both sides by some measure which is likely to produce a small
+    # maximum value of (sorted_rotated_index - sorted_original_index).
+    # The C code is optimized for this case, reducing an O(n^2)
+    # search down to ~O(n). (for O(n log n) work overall, including the sort)
+    #
+    # We choose distance from the nearest bravais lattice point as our measure.
+    def sort_by_lattice_distance(fracs):
+        carts = np.dot(fracs - np.rint(fracs), lattice.T)
+        perm = np.argsort(np.sum(carts**2, axis=1))
+        sorted_fracs = fracs[perm]
+        return perm, sorted_fracs
+
+    (perm_a, sorted_a) = sort_by_lattice_distance(positions_a)
+    (perm_b, sorted_b) = sort_by_lattice_distance(positions_b)
+
+    # Call the C code on our conditioned inputs.
+    perm_between = _compute_permutation_c(sorted_a,
+                                          sorted_b,
+                                          lattice,
+                                          symprec)
+
+    # Compose all of the permutations for the full permutation.
+    #
+    # Note the following properties of permutation arrays:
+    #
+    # 1. Inverse:         if  x[perm] == y  then  x == y[argsort(perm)]
+    # 2. Associativity:   x[p][q] == x[p[q]]
+    return perm_a[perm_between][np.argsort(perm_b)]
+
+# Version of '_compute_permutation_for_rotation' which just directly calls the C function,
+# without any conditioning of the data.
+#
+# Skipping the conditioning step makes this EXTREMELY slow on large structures.
+def _compute_permutation_c(positions_a, # scaled positions
+                           positions_b,
+                           lattice, # column vectors
+                           symprec):
+
+    permutation = np.zeros(shape=(len(positions_a),), dtype='intc')
+
+    def permutation_error():
+        raise ValueError("Input forces are not enough to calculate force constants, "
+                         "or something wrong (e.g. crystal structure does not match).")
+
+    try:
+        import phonopy._phonopy as phonoc
+        is_found = phonoc.compute_permutation(permutation,
+                                              lattice,
+                                              positions_a,
+                                              positions_b,
+                                              symprec)
+
+        if not is_found:
+            permutation_error()
+
+    except ImportError:
+        symprec2 = symprec**2
+
+        for i, pos_b in enumerate(positions_b):
+            diffs = positions_a - pos_b
+            diffs -= np.rint(diffs)
+            diffs = np.dot(diffs, lattice.T)
+
+            possible_j = np.nonzero(np.sum(diffs**2, axis=1) < symprec2)[0]
+            if len(possible_j) != 1:
+                permutation_error()
+
+            permutation[i] = possible_j[0]
+
+        if -1 in permutation:
+            permutation_error()
+
+    return permutation


### PR DESCRIPTION
This adds `_compute_permutation` which is an implementation of the overlap searches in `distribute_fc2`, but with performance characteristics that scale better for very large structures.

The key to its speed [actually lies here, in the python bits](https://github.com/ExpHP/phonopy/blob/eigenvector-hack/phonopy/harmonic/force_constants.py#L683-L693): Sorting is used to precondition the data into a form that lets `compute_permutation` work fast.

**NOTICE: In this commit, `distribute_fc2` still does not yet use the new function!!**  That is because I haven't yet figured out how to incorporate all of your recent changes.

FYI, here's how I used to use it, back before you added `distribute_fc2_all`:

* I used it to [break `_distribute_fc2_part` into two steps](https://github.com/ExpHP/phonopy/blob/eigenvector-hack/phonopy/harmonic/force_constants.py#L647-L671)
* The second step was [just this simple C function](https://github.com/ExpHP/phonopy/blob/eigenvector-hack/c/_phonopy.c#L690-L716)

---

However, we still get big wins in this commit, because I was able to use it in `get_positions_sent_by_rot_inv` instead.  On [these input files](https://github.com/ExpHP/phonopy-eigenvector-tblg-benchmark/tree/master/input/big), this change speeds that function up from taking ~50s (out of ~250s total runtime for `--readfc --band=...`) down to only taking ~0.12s.