### PR TITLE
add pyproject.toml to declare numpy as build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy"]


### PR DESCRIPTION
Replaces https://github.com/atztogo/phonopy/pull/97 where `wheel` was not included.