### PR TITLE
spelling error when outputting FC to phonopy.yaml

### DIFF
--- a/phonopy/interface/phonopy_yaml.py
+++ b/phonopy/interface/phonopy_yaml.py
@@ -247,7 +247,7 @@ class PhonopyYaml(object):
             lines += self._displacements_yaml_lines()
 
         if self.settings['force_constants']:
-            lines += self.force_constants_yaml_lines()
+            lines += self._force_constants_yaml_lines()
 
         return lines
 


### PR DESCRIPTION
When writing force constants file to phonopy.yaml, raises AttributeError. Fixed a spelling error by adding an underscore in the function name call and now it works.